### PR TITLE
Remove reference to orthonormal AO basis

### DIFF
--- a/project/rhf.ipynb
+++ b/project/rhf.ipynb
@@ -246,9 +246,7 @@
     "    - If change in RHF energy less than E_conv, break    \n",
     "    - Save latest RHF energy as E_old\n",
     "3. Compute new orbital guess\n",
-    "    - Transform Fock matrix to orthonormal AO basis    \n",
-    "    - Diagonalize ${\\bf F}'$ for $\\epsilon$ and ${\\bf C}'$    \n",
-    "    - Back transform ${\\bf C}'$ to AO basis    \n",
+    "    - Diagonalize ${\\bf F}$ for $\\epsilon$ and ${\\bf C}$    \n",
     "    - Form **D** from occupied orbital slice of **C**"
    ]
   },


### PR DESCRIPTION
Seems like a copy-paste issue from the computational chemistry RHF implementation to the bootcamp RHF implementation. In this implementation where scipy is used, the *generalised* eigenequation can be solved directly, thus any mention of AO basis transformation into an orthonormal basis is not needed and causes confusion.